### PR TITLE
General call enhancements

### DIFF
--- a/calls/general.md
+++ b/calls/general.md
@@ -87,7 +87,7 @@ The deadline for panel discussion is some weeks before the conference (i.e. afte
 
 <h3 id="submission-other">Other</h3>
 
-Your submission does not fit into any of these submission types? Please get in touch with the program committee via email (<a hrf="mailto:program-sotm@openstreetmap.org>program-sotm@openstreetmap.org</a>) before the end of the call for participation.
+Your submission does not fit into any of these submission types? Please get in touch with the program committee via email (<a href="mailto:program-sotm@openstreetmap.org">program-sotm@openstreetmap.org</a>) before the end of the call for participation.
 
 
 <h2 id="other-submission">Other session types</h2>

--- a/calls/general.md
+++ b/calls/general.md
@@ -168,11 +168,11 @@ We hope this detailed “Call for Presentations” helps to increase the transpa
 
 <h2 id="timeline_deadlines">Timeline and Deadlines</h2>
 
-* 4 April 2021: Deadline talk and workshop submissions
+* 4 April 2021 23:59:59 UTC: Deadline talk and workshop submissions
 * TBD: Deadline academic talk submissions
 * End of April 2021: End of review phase, speakers will be informed
 * May 2021: Talk video production (test video and final video)
-* 6 June 2021: Deadline panel submissions
+* 6 June 2021 23:59:59 UTC: Deadline panel submissions
 * June 2021: Lightning talk video production
 * 9-11 July 2021: State of the Map
 


### PR DESCRIPTION
When skimming the [CfP on the website](https://2021.stateofthemap.org/calls/general/), I noticed a small typo in a `mailto:` link and that we didn't add the time and time zone to the submission deadlines which is an omission that usually leads to confusion, so I'm adding it here as well.