### PR TITLE
Fix selector for schedule table cell with time zone information

### DIFF
--- a/_includes/_timezoneswitcher.html
+++ b/_includes/_timezoneswitcher.html
@@ -17,7 +17,7 @@
         if (zone[0] == '+' || zone[0] == '-') {
           zone = 'UTC ' + zone;
         }
-        $('.scheduleTable > thead > tr > td:first-child').text(tz == 'UTC'
+        $('.scheduleTable > thead > tr > th:first-child').text(tz == 'UTC'
           ? 'Time (UTC)'
           : 'Local Time (' + zone + ')'
         );


### PR DESCRIPTION
The time zone information of the schedule table head is in a `<th>` element, not `<td>`, so the original selector didn't match and the table was always showing `Time (UTC)` even after switching the time zone in the selector. This should be fixed by the change in this PR.