### PR TITLE
fix broken live stream link on new pop up

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
                     <p>There are several different ways to attend SotM&nbsp;2021:
                       <ul>
                         <li>Got a ticket? Join the interactive virtual conference platform over at <a style="font-weight:bold; white-space: nowrap; text-shadow: 0 0 4px white;" href="https://sotm2021.venueless.events/">venueless</a>. You received a personal invite link with your ticket.</li>
-                        <li>The main track will be <a href="./streaming" style="font-weight:bold; white-space: nowrap; text-shadow: 0 0 4px white;">live streamed</a> publicly.</li>
+                        <li>The main track will be <a href="./stream" style="font-weight:bold; white-space: nowrap; text-shadow: 0 0 4px white;">live streamed</a> publicly.</li>
                         <li>Follow <a href="https://twitter.com/sotm">@SotM</a> on Twitter and use the hashtag <a href="https://twitter.com/hashtag/sotm2021">#sotm2021</a> when tweeting.</li>
                       </ul>
                     </p>


### PR DESCRIPTION
On commit 2bbb45de66f4adce3a50a06940ae02ea0a5162fc the pop up on the main page got a direct link to the live stream sub page. But the link should be /stream and not /streaming, resulting in a 404 error.